### PR TITLE
gRPC requires java.instrument module

### DIFF
--- a/armeria-sandbox-backend2/Dockerfile.production
+++ b/armeria-sandbox-backend2/Dockerfile.production
@@ -2,7 +2,7 @@ FROM azul/zulu-openjdk-alpine:11.0.3 as builder
 
 RUN jlink \
     --compress=2 \
-    --add-modules=java.base,java.logging,java.sql,java.desktop,jdk.management,jdk.management.agent,jdk.naming.dns,jdk.unsupported \
+    --add-modules=java.base,java.logging,java.sql,java.desktop,jdk.management,jdk.management.agent,jdk.naming.dns,jdk.unsupported,java.instrument \
     --bind-services \
     --output=/tmp/jre
 


### PR DESCRIPTION
see also: https://docs.oracle.com/en/java/javase/11/docs/api/java.instrument/java/lang/instrument/ClassFileTransformer.html

```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.linecorp.armeria.spring.GrpcServiceRegistrationBean]: Factory method 'pingService' threw exception; nested exception is java.lang.NoClassDefFoundError: java/lang/instrument/ClassFileTransformer
...
Caused by: java.lang.ClassNotFoundException: java.lang.instrument.ClassFileTransformer
 	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:471) ~[na:na]
 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588) ~[na:na]
 	at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:93) ~[app.jar:na]
 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521) ~[na:na]
```